### PR TITLE
60 xsitype should always be interpreted as a qname

### DIFF
--- a/.changeset/small-maps-juggle.md
+++ b/.changeset/small-maps-juggle.md
@@ -1,0 +1,5 @@
+---
+"cruftless": patch
+---
+
+Fixes #60, preventing us from parsing documents that use other namespace prefixes than the ones used in the `xsi:type` definitions in the binding template.

--- a/README.js.md
+++ b/README.js.md
@@ -335,26 +335,42 @@ but for students you need a different content model than for teachers. Then you
 could model that using `xsi:type`.
 
 ```javascript --run simple-2
-template = parse(`
+template = parse(
+  `
 <people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <person xsi:type="Student" c-bind="people|array" nickName="{{name}}" grade="{{grade}}" />
   <person xsi:type="Teacher" c-bind="people|array" name="{{name}}" subject="{{subject}}" />
 </people>
-`.trim());
+`.trim()
+);
 
-console.log(template.fromXML(`
+console.log(
+  template.fromXML(
+    `
 <people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <person xsi:type="Student" nickName="Jesse" grade="D" />
   <person xsi:type="Student" nickName="Badger" grade="C" />
   <person xsi:type="Teacher" name="Walther" subject="chemistry" />
 </people>
-`.trim()));
+`.trim()
+  )
+);
 ```
 
 In the above case, the `xsi:type` attribute determines the content model of the
 data getting parsed. It will pass the value to the `kind` property of the data
 extracted. Reversely, it will use the `kind` property to determine how to render
 the data as XML.
+
+Now, `xsi:type` values are assumed to `QName`s. That means that there might be a
+prefix in the name that resolves to a namespace. The documents that you _parse_
+might use different namespace prefixes than the binding template. In order to
+avoid issues with that, Cruftless accepts a `prefixes` option specifically for
+normalization of the prefixes. So, if your template refers to a type with an
+`ns1:` prefix, and the document you are passing is using the `ns0:` prefix, then
+you can make sure the types in the documents you are parsing are rewritten to
+`ns1`, by the namespace of `ns1` in the configuration options of your Cruftless
+instance.
 
 **NOTE:** There are [various
 issues](https://github.com/wspringer/cruftless/issues/50) with the way RelaxNG

--- a/README.js.md
+++ b/README.js.md
@@ -370,7 +370,7 @@ normalization of the prefixes. So, if your template refers to a type with an
 `ns1:` prefix, and the document you are passing is using the `ns0:` prefix, then
 you can make sure the types in the documents you are parsing are rewritten to
 `ns1`, by the namespace of `ns1` in the configuration options of your Cruftless
-instance.
+instance. (See <https://github.com/wspringer/cruftless/blob/60-xsitype-should-always-be-interpreted-as-a-qname/test/model/xsi-type-test.coffee#L84>.)
 
 **NOTE:** There are [various
 issues](https://github.com/wspringer/cruftless/issues/50) with the way RelaxNG

--- a/README.md
+++ b/README.md
@@ -425,20 +425,26 @@ but for students you need a different content model than for teachers. Then you
 could model that using `xsi:type`.
 
 ```javascript
-template = parse(`
+template = parse(
+  `
 <people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <person xsi:type="Student" c-bind="people|array" nickName="{{name}}" grade="{{grade}}" />
   <person xsi:type="Teacher" c-bind="people|array" name="{{name}}" subject="{{subject}}" />
 </people>
-`.trim());
+`.trim()
+);
 
-console.log(template.fromXML(`
+console.log(
+  template.fromXML(
+    `
 <people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <person xsi:type="Student" nickName="Jesse" grade="D" />
   <person xsi:type="Student" nickName="Badger" grade="C" />
   <person xsi:type="Teacher" name="Walther" subject="chemistry" />
 </people>
-`.trim()));
+`.trim()
+  )
+);
 ⇒ {
 ⇒   people: [
 ⇒     { name: 'Jesse', grade: 'D', kind: 'Student' },
@@ -452,6 +458,16 @@ In the above case, the `xsi:type` attribute determines the content model of the
 data getting parsed. It will pass the value to the `kind` property of the data
 extracted. Reversely, it will use the `kind` property to determine how to render
 the data as XML.
+
+Now, `xsi:type` values are assumed to `QName`s. That means that there might be a
+prefix in the name that resolves to a namespace. The documents that you _parse_
+might use different namespace prefixes than the binding template. In order to
+avoid issues with that, Cruftless accepts a `prefixes` option specifically for
+normalization of the prefixes. So, if your template refers to a type with an
+`ns1:` prefix, and the document you are passing is using the `ns0:` prefix, then
+you can make sure the types in the documents you are parsing are rewritten to
+`ns1`, by the namespace of `ns1` in the configuration options of your Cruftless
+instance. (See <https://github.com/wspringer/cruftless/blob/60-xsitype-should-always-be-interpreted-as-a-qname/test/model/xsi-type-test.coffee#L84>.)
 
 **NOTE:** There are [various
 issues](https://github.com/wspringer/cruftless/issues/50) with the way RelaxNG

--- a/cruftless.d.ts
+++ b/cruftless.d.ts
@@ -24,6 +24,7 @@ declare module "cruftless" {
      */
     relaxng: (...args: any[]) => Template<unknown>;
   }
+
   export interface CruftlessOpts {
     types: CruftlessTypes;
     /**
@@ -31,6 +32,12 @@ declare module "cruftless" {
      * of a content model. Used in case of xsi:type.
      */
     kindProperty?: string;
+
+    /**
+     * Prefix mapping for namespaces. Prefixes are the keys, namespaces are the values.
+     * Used for xsi:type canonicalization.
+     */
+    prefixes?: Record<string, string>;
   }
 
   export interface Cruftless {

--- a/src/cruftless.coffee
+++ b/src/cruftless.coffee
@@ -8,6 +8,8 @@ module.exports = (opts = {}) ->
 
   opts.kindProperty = opts.kindProperty or 'kind'
 
+  opts.prefixes = opts.prefixes or {}
+
   element = require('./model/element')(opts)
 
   attr = require('./model/attr')(opts)

--- a/test/model/xsi-type-test.coffee
+++ b/test/model/xsi-type-test.coffee
@@ -1,4 +1,8 @@
-{ parse, attr, element, text } = require('../../src/cruftless')()
+{ parse, attr, element, text } = require('../../src/cruftless')({
+  prefixes: {
+    ase: 'http://foo.bar/'
+  }
+})
 { xsiNS } = require '../../src/ns'
 
 
@@ -71,4 +75,10 @@ describe 'xsi:type support', ->
     </foo>""".trim())
     expect(template.toXML(as: [{b: '3', kind: 'B'}, {c: '4', kind: 'C'}])).toEqual('<foo xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><bar xsi:type=\"B\">3</bar><bar xsi:type=\"C\">4</bar></foo>')
 
-
+  it 'should be flexible in terms of namespace prefixes', ->
+    template = parse("""
+    <foo xmlns:xsi='#{xsiNS}'>
+    <bar c-bind="b|object" xsi:type='ase:B'>{{name}}</bar>
+    </foo>""".trim())
+    expect(template.fromXML('<foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><bar xsi:type="ase:B">3</bar></foo>')).toEqual { b: { kind: 'ase:B', name: '3' } }
+    expect(template.fromXML('<foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://foo.bar/"><bar xsi:type="ns0:B">3</bar></foo>')).toEqual { b: { kind: 'ase:B', name: '3' } }


### PR DESCRIPTION
- Allows us to fix a parsing problem
- Document the change
- Document the change
